### PR TITLE
add yarn files to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 node_modules
 /data-generator/data/
 .history
+web/.yarn/install-state.gz
+web/.yarnrc.yml
+web/yarn.lock


### PR DESCRIPTION
I added the yarn files to the gitignore files because they cause nightmares when trying to resolve merge conflicts and after looking deeper into it learned they should really be ignored because they're generated anyways when we install and build a project.